### PR TITLE
[Bugfix] Comparison issue when facing with inverted (negated) rule that have whole field with specific action

### DIFF
--- a/dist/cjs/core/comparator/abilityChecker.js
+++ b/dist/cjs/core/comparator/abilityChecker.js
@@ -65,28 +65,32 @@ class AbilityChecker {
             scope = argumentLength >= 3 ? args[2] : scope;
             field = argumentLength >= 4 ? args[3] : null;
         }
-        const specificActionRules = this.compiledRules.queryRule(scope, resource, action);
+        const unspecifiedActionRules = this.compiledRules.queryRule(scope, resource, '');
         const specificNormalRules = [];
-        for (const specificActionRule of specificActionRules) {
+        const starActionRules = [];
+        for (const unspecifiedActionRule of unspecifiedActionRules) {
             /** 1. Checking on specific inverted rules */
-            if (specificActionRule.inverted()) {
-                if (specificActionRule.getResource().matchField(field)) {
-                    return false; // as the correspondent user is prohibited access resource
-                }
+            if (unspecifiedActionRule.inverted() &&
+                unspecifiedActionRule.getResource().matchField(field) &&
+                unspecifiedActionRule.getAction().match(action)) {
+                return false; // as the correspondent user is prohibited access resource
             }
-            else {
-                specificNormalRules.push(specificActionRule);
+            else if (unspecifiedActionRule.getAction().wholeAction()) {
+                starActionRules.push(unspecifiedActionRule);
+            }
+            else if (unspecifiedActionRule.getAction().get() === action) {
+                specificNormalRules.push(unspecifiedActionRule);
             }
         }
         /** 2. Star-<action> rules */
-        const starActionRules = this.compiledRules.queryRule(scope, resource, '*');
+        // const starActionRules = this.compiledRules.queryRule(scope, resource, '*');
         for (const startActionRule of starActionRules) {
             if (startActionRule.getResource().matchField(field)) {
                 return !startActionRule.inverted();
             }
         }
         /** 3. Other specific-<action> rules */
-        for (const specificNormalRule of specificActionRules) {
+        for (const specificNormalRule of specificNormalRules) {
             if (specificNormalRule.getResource().matchField(field)) {
                 return true;
             }

--- a/dist/cjs/core/objects/action.d.ts
+++ b/dist/cjs/core/objects/action.d.ts
@@ -10,4 +10,5 @@ export declare class Action {
     get(): string;
     wholeAction(): boolean;
     toString(): string;
+    match(action: string): boolean;
 }

--- a/dist/cjs/core/objects/action.js
+++ b/dist/cjs/core/objects/action.js
@@ -27,5 +27,11 @@ class Action {
     toString() {
         return this.get();
     }
+    match(action) {
+        if (this.wholeAction()) {
+            return true;
+        }
+        return this.get() === action;
+    }
 }
 exports.Action = Action;

--- a/dist/esm/core/objects/action.d.ts
+++ b/dist/esm/core/objects/action.d.ts
@@ -10,4 +10,5 @@ export declare class Action {
     get(): string;
     wholeAction(): boolean;
     toString(): string;
+    match(action: string): boolean;
 }

--- a/dist/esm/core/objects/action.js
+++ b/dist/esm/core/objects/action.js
@@ -24,4 +24,10 @@ export class Action {
     toString() {
         return this.get();
     }
+    match(action) {
+        if (this.wholeAction()) {
+            return true;
+        }
+        return this.get() === action;
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dicoding-dev/abilities-js",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dicoding-dev/abilities-js",
-      "version": "0.5.9",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "object-deep-compare": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dicoding-dev/abilities-js",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "A core package for managing the authorization through CanCanCan style. With supports of granularity based on Attributes Based Access Control.",
   "source": "src/index.ts",
   "main": "dist/cjs/index.js",

--- a/src/core/comparator/abilityChecker.test.ts
+++ b/src/core/comparator/abilityChecker.test.ts
@@ -154,6 +154,33 @@ describe('can() feature function test', function () {
         expect(abilityChecker.can('update', 'resource1', 'scope1', {'author' : 666}))
             .toBeFalsy();
     });
+
+    it('must return as expected when has inverted specific action and whole field rule compared with rule that has specific field with whole action', function () {
+        const compiledRules = new CompiledRules([
+            {
+                'id' : 2,
+                'rule' : '!scope1:resource1/*:review'
+            },
+            {
+                'id' : 3,
+                'rule' : 'scope1:resource1/{"author": 667}:*'
+            }
+        ]);
+
+        const abilityChecker = new AbilityChecker(compiledRules);
+        expect(abilityChecker.can('update', 'resource1', 'scope1', {'author' : 667}))
+            .toBe(true);
+        expect(abilityChecker.can('update', 'resource1', 'scope1'))
+            .toBe(false);
+        expect(abilityChecker.can('*', 'resource1', 'scope1'))
+            .toBe(false);
+        expect(abilityChecker.can('review', 'resource1', 'scope1', {'author' : 667}))
+            .toBe(false);
+        expect(abilityChecker.can('review', 'resource1', 'scope1'))
+            .toBe(false);
+        expect(abilityChecker.can('review', 'resource1', 'scope1', {'author' : 666}))
+            .toBe(false);
+    });
 });
 
 describe('cannot() feature function test', function () {

--- a/src/core/comparator/abilityChecker.ts
+++ b/src/core/comparator/abilityChecker.ts
@@ -77,7 +77,9 @@ export class AbilityChecker {
 
         for(const unspecifiedActionRule of unspecifiedActionRules) {
             /** 1. Checking on specific inverted rules */
-            if (unspecifiedActionRule.inverted() && unspecifiedActionRule.getResource().matchField(field)) {
+            if (unspecifiedActionRule.inverted() &&
+                unspecifiedActionRule.getResource().matchField(field) &&
+                unspecifiedActionRule.getAction().match(action)) {
                 return false; // as the correspondent user is prohibited access resource
             } else if (unspecifiedActionRule.getAction().wholeAction()) {
                 starActionRules.push(unspecifiedActionRule);

--- a/src/core/objects/action.test.ts
+++ b/src/core/objects/action.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, test } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import { Action } from "./action";
 
 it('must fail when assigned with empty value', () => {
@@ -29,3 +29,23 @@ test("Successfully define specific action", function () {
 it('can know if the action is whole action (star)', function () {
     expect((new Action('*')).wholeAction()).toBe(true);
 });
+
+describe('match() function test', function () {
+    it('must return true when the current action is whole action', function () {
+        const currentAction = new Action();
+ 
+        expect(currentAction.match('create')).toBe(true);
+        expect(currentAction.match('*')).toBe(true);
+    });
+ 
+    it ('must return true when the match with specific action', function () {
+        const currentAction = new Action('create');
+        expect(currentAction.match('create')).toBe(true);
+    });
+ 
+    it('must return false when not match with specific action', function () {
+        const currentAction = new Action('create');
+        expect(currentAction.match('update')).toBe(false);
+    });
+ });
+ 

--- a/src/core/objects/action.ts
+++ b/src/core/objects/action.ts
@@ -32,4 +32,13 @@ export class Action {
     toString(): string {
         return this.get();
     }
+
+    match(action: string): boolean
+    {
+        if (this.wholeAction()) {
+            return true;
+        }
+
+        return this.get() === action;
+    }
 }


### PR DESCRIPTION
## About

This PR will fix a bug when checking the user abilities.

Example: 
User A have a list of these rules : 
```
!scope:resourceA/*:review
scope:resourceA/{"author": 'A'}:*
``` 
This rules means that the User A : 
1. Cannot do `review` on all field of `resourceA`
2. Can do anything (except `review`) on `resourceA` authored by User A (specific author field)

**Current Condition** 
The engine will return false when User A want to check his/her capability for doing create, update, or anything (except `review`) on `resourceA`. So, it's contradict with the behavior of the engine.

**Expected Condition**
The engine must return true as the User A have anything capabilities on resource `resourceA` with his/her as author (identified by specific field)
